### PR TITLE
Reset method to GET.

### DIFF
--- a/src/Congow/Orient/Http/Client/Curl.php
+++ b/src/Congow/Orient/Http/Client/Curl.php
@@ -111,6 +111,8 @@ class Curl implements HttpClient
      */
     public function get($location)
     {
+    	curl_setopt($this->client, CURLOPT_HTTPGET, true);
+        
         return $this->execute('GET', $location);
     }
 


### PR DESCRIPTION
Reset method to GET. After changing method with CURLOPT_CUSTOMREQUEST it stays changed. So executing e.g. POST and then GET currently fails. See https://github.com/zpi2011asvis/asvis/blob/master/tests/reinmar/insert_random.php

BTW. why You pass http method name to execute() method while You don't use it there?
