### PR TITLE
Do not use the APC-based cache-provider for annotations when APC is not available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ THE SOFTWARE
 These are the requirements in order to use the library:
 
 * PHP >= 5.3.3
-* APC
 * OrientDB 1.0.0RC6
+* APC (optional, used by the annotation reader as a cache)
 
 In order to launch the test suite PHPUnit 3.5 is required.
 

--- a/src/Congow/Orient/ODM/Mapper/Annotations/Reader.php
+++ b/src/Congow/Orient/ODM/Mapper/Annotations/Reader.php
@@ -31,6 +31,7 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Annotations\Parser;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 class Reader implements ReaderInterface
@@ -47,7 +48,7 @@ class Reader implements ReaderInterface
     public function __construct(Cache $cacheReader = null)
     {
         if (!$cacheReader) {
-            $cacheReader = new ApcCache;
+            $cacheReader = $this->createCacheProvider();
         }
         
         $this->reader = new CachedReader(new AnnotationReader, $cacheReader);
@@ -138,5 +139,15 @@ class Reader implements ReaderInterface
     protected function getReader()
     {
         return $this->reader;
+    }
+
+    /**
+     * Creates a new instance of a cache provider.
+     *
+     * @return Doctrine\Common\Cache\CacheProvider
+     */
+    protected function createCacheProvider()
+    {
+        return function_exists('apc_fetch') ? new ApcCache() : new ArrayCache();
     }
 }


### PR DESCRIPTION
It is quite common to have a development environment that does not have the APC extension configured or loaded (especially when using php-cli), so I think that having the annotation reader to automatically fall back to the basic [ArrayCache](https://github.com/doctrine/common/blob/b385ca770888248241bd3086a40d5b3bd082a706/lib/Doctrine/Common/Cache/ArrayCache.php) of Doctrine for annotations might be the best way to handle this.
