### PR TITLE
Use a method instead of a constant to return the schema of a query.

### DIFF
--- a/src/Congow/Orient/Contract/Query/Command.php
+++ b/src/Congow/Orient/Contract/Query/Command.php
@@ -24,8 +24,6 @@ use \Congow\Orient\Contract\Query\Formatter;
 
 interface Command
 {
-    const SCHEMA = null;
-
     /**
      * Sets a where token using the AND operator.
      * If the $condition contains a "?", it will be replaced by the $value.
@@ -61,7 +59,7 @@ interface Command
      *
      * @return   array
      */
-    public static function getTokens();
+    public function getTokens();
 
     /**
      * Returns the value of the given $token.

--- a/src/Congow/Orient/Query/Command.php
+++ b/src/Congow/Orient/Query/Command.php
@@ -32,7 +32,6 @@ abstract class Command implements CommandContract
 {
     protected $tokens       = array();
     protected $formatters   = array();
-    protected $statement    = null;
     protected $formatter    = null;
 
     /**
@@ -41,9 +40,15 @@ abstract class Command implements CommandContract
      */
     public function __construct()
     {
-        $class              = get_called_class();
-        $this->statement    = $class::SCHEMA;
-        $this->tokens       = $this->getTokens();
+        $this->tokens = $this->getTokens();
+    }
+
+    /**
+     * Returns the schema template for the command.
+     */
+    protected function getSchema()
+    {
+        return null;
     }
 
     /**
@@ -88,11 +93,10 @@ abstract class Command implements CommandContract
      *
      * @return array
      */
-    public static function getTokens()
+    public function getTokens()
     {
-        $class  = get_called_class();
         $tokens = array();
-        preg_match_all("/(\:\w+)/", $class::SCHEMA, $matches);
+        preg_match_all("/(\:\w+)/", $this->getSchema(), $matches);
 
         foreach ($matches[0] as $match) {
             $tokens[$match] = array();
@@ -335,7 +339,8 @@ abstract class Command implements CommandContract
      */
     protected function getValidStatement()
     {
-        $statement = $this->replaceTokens($this->statement);
+        $schema = $this->getSchema();
+        $statement = $this->replaceTokens($schema);
         $statement = preg_replace('/( ){2,}/', ' ', $statement);
 
         return trim($statement);

--- a/src/Congow/Orient/Query/Command/Credential/Grant.php
+++ b/src/Congow/Orient/Query/Command/Credential/Grant.php
@@ -24,7 +24,11 @@ use Congow\Orient\Query\Command\Credential;
 
 class Grant extends Credential implements CredentialInterface
 {
-    const SCHEMA =
-        "GRANT :Permission ON :Resource TO :Role"
-    ;
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "GRANT :Permission ON :Resource TO :Role";
+    }
 }

--- a/src/Congow/Orient/Query/Command/Credential/Revoke.php
+++ b/src/Congow/Orient/Query/Command/Credential/Revoke.php
@@ -24,7 +24,11 @@ use Congow\Orient\Query\Command\Credential;
 
 class Revoke extends Credential
 {
-    const SCHEMA =
-        "REVOKE :Permission ON :Resource FROM :Role"
-    ;
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "REVOKE :Permission ON :Resource FROM :Role";
+    }
 }

--- a/src/Congow/Orient/Query/Command/Delete.php
+++ b/src/Congow/Orient/Query/Command/Delete.php
@@ -24,8 +24,6 @@ use Congow\Orient\Query\Command;
 
 class Delete extends Command
 {
-    const SCHEMA = "DELETE FROM :Class :Where";
-
     /**
      * Builds a new statement, setting the class in which the records are gonna
      * be deleted.
@@ -37,6 +35,14 @@ class Delete extends Command
         parent::__construct();
 
         $this->setClass($from);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "DELETE FROM :Class :Where";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Index/Count.php
+++ b/src/Congow/Orient/Query/Command/Index/Count.php
@@ -24,8 +24,6 @@ use Congow\Orient\Query\Command;
 
 class Count extends Index
 {
-    const SCHEMA = "SELECT count(*) AS size from index::Name";
-
     /**
      * Sets the $property to index.
      * Optionally, you can specify the property $class and the $type of the
@@ -40,6 +38,14 @@ class Count extends Index
         parent::__construct();
 
         $this->setToken('Name', $indexName);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "SELECT count(*) AS size from index::Name";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Index/Create.php
+++ b/src/Congow/Orient/Query/Command/Index/Create.php
@@ -24,8 +24,6 @@ use Congow\Orient\Query\Command;
 
 class Create extends Index
 {
-    const SCHEMA = "CREATE INDEX :IndexClass:Property :Type";
-
     /**
      * Sets the $property to index.
      * Optionally, you can specify the property $class and the $type of the
@@ -45,6 +43,14 @@ class Create extends Index
 
         $this->type($type);        
         $this->setToken('Property', $property);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "CREATE INDEX :IndexClass:Property :Type";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Index/Drop.php
+++ b/src/Congow/Orient/Query/Command/Index/Drop.php
@@ -23,8 +23,6 @@ use Congow\Orient\Query\Command\Index;
 
 class Drop extends Index
 {
-    const SCHEMA = "DROP INDEX :IndexClass:Property";
-
     /**
      * Creates a new statements to manage indexes on the $property of the given
      * $class.
@@ -41,5 +39,13 @@ class Drop extends Index
         }
 
         $this->setToken('Property', $property);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "DROP INDEX :IndexClass:Property";
     }
 }

--- a/src/Congow/Orient/Query/Command/Index/Lookup.php
+++ b/src/Congow/Orient/Query/Command/Index/Lookup.php
@@ -24,8 +24,6 @@ use Congow\Orient\Query\Command;
 
 class Lookup extends Index
 {
-    const SCHEMA = "SELECT FROM index::Index :Where";
-
     /**
      * Builds a new statement, setting the $index to lookup.
      *
@@ -36,6 +34,14 @@ class Lookup extends Index
         parent::__construct();
 
         $this->setToken('Index', $index);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "SELECT FROM index::Index :Where";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Index/Put.php
+++ b/src/Congow/Orient/Query/Command/Index/Put.php
@@ -24,8 +24,6 @@ use Congow\Orient\Query\Command;
 
 class Put extends Index
 {
-    const SCHEMA = "INSERT INTO index::Name (key,rid) values (\":Key\", :Value)";
-
     /**
      * Creates a new instance of this command setting the index to insert into,
      * the key of the new entry and its value, which is a RID.
@@ -41,6 +39,14 @@ class Put extends Index
         $this->setToken('Name', $indexName);
         $this->setToken('Key', $key);
         $this->setToken('Value', $rid);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "INSERT INTO index::Name (key,rid) values (\":Key\", :Value)";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Index/Remove.php
+++ b/src/Congow/Orient/Query/Command/Index/Remove.php
@@ -25,8 +25,6 @@ use Congow\Orient\Formatter\Query\EmbeddedRid as EmbeddedRidFormatter;
 
 class Remove extends Index
 {
-    const SCHEMA = "DELETE FROM index::Name :Where";
-
     public function __construct($indexName, $key, $rid = null, TokenFormatter $ridFormatter = null)
     {
         parent::__construct();
@@ -43,6 +41,14 @@ class Remove extends Index
             $rid    = $ridFormatter::format(array($rid));
             $this->$method("rid = $rid");
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "DELETE FROM index::Name :Where";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Insert.php
+++ b/src/Congow/Orient/Query/Command/Insert.php
@@ -24,10 +24,6 @@ use Congow\Orient\Query\Command;
 
 class Insert extends Command implements InsertInterface
 {
-    const SCHEMA =
-        "INSERT INTO :Target (:Fields) VALUES (:Values)"
-    ;
-
     /**
      * Sets the fields to insert within the query.
      *
@@ -40,6 +36,14 @@ class Insert extends Command implements InsertInterface
         $this->setTokenValues('Fields', $fields, $append);
 
         return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "INSERT INTO :Target (:Fields) VALUES (:Values)";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Link.php
+++ b/src/Congow/Orient/Query/Command/Link.php
@@ -24,10 +24,6 @@ use Congow\Orient\Query\Command;
 
 class Link extends Command
 {
-    const SCHEMA =
-        "CREATE LINK :Name FROM :SourceClass.:SourceProperty TO :DestinationClass.:DestinationProperty :Inverse"
-    ;
-
     /**
      * Sets the source of the link, its $alias and if the link must be $reverse.
      *
@@ -47,6 +43,14 @@ class Link extends Command
         if ($inverse) {
             $this->setToken('Inverse', 'INVERSE');
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "CREATE LINK :Name FROM :SourceClass.:SourceProperty TO :DestinationClass.:DestinationProperty :Inverse";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/OClass/Alter.php
+++ b/src/Congow/Orient/Query/Command/OClass/Alter.php
@@ -23,8 +23,6 @@ use Congow\Orient\Query\Command\OClass;
 
 class Alter extends OClass
 {
-    const SCHEMA = "ALTER CLASS :Class :Attribute :Value";
-
     /**
      * Sets the $class to alter, setting the $attribute to its new $value.
      *
@@ -38,6 +36,14 @@ class Alter extends OClass
 
         $this->setToken('Attribute', $attribute);
         $this->setToken('Value', $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "ALTER CLASS :Class :Attribute :Value";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/OClass/Create.php
+++ b/src/Congow/Orient/Query/Command/OClass/Create.php
@@ -24,5 +24,11 @@ use Congow\Orient\Query\Command\OClass;
 
 class Create extends OClass implements OClassInterface
 {
-    const SCHEMA = "CREATE CLASS :Class";
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "CREATE CLASS :Class";
+    }
 }

--- a/src/Congow/Orient/Query/Command/OClass/Drop.php
+++ b/src/Congow/Orient/Query/Command/OClass/Drop.php
@@ -24,5 +24,11 @@ use Congow\Orient\Query\Command\OClass;
 
 class Drop extends OClass implements OClassInterface
 {
-    const SCHEMA = "DROP CLASS :Class";
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "DROP CLASS :Class";
+    }
 }

--- a/src/Congow/Orient/Query/Command/Property/Alter.php
+++ b/src/Congow/Orient/Query/Command/Property/Alter.php
@@ -23,8 +23,6 @@ use Congow\Orient\Query\Command\Property;
 
 class Alter extends Property
 {
-    const SCHEMA = "ALTER PROPERTY :Class.:Property :Attribute :Value";
-
     /**
      * Sets the $attribute to change and its new $value.
      *
@@ -38,6 +36,14 @@ class Alter extends Property
         $this->setToken('Value', $value);
 
         return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "ALTER PROPERTY :Class.:Property :Attribute :Value";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Property/Create.php
+++ b/src/Congow/Orient/Query/Command/Property/Create.php
@@ -23,8 +23,6 @@ use Congow\Orient\Query\Command\Property;
 
 class Create extends Property
 {
-    const SCHEMA = "CREATE PROPERTY :Class.:Property :Type :Linked";
-
     /**
      * Generates a valid SQL statements to add $property of type $type
      * linked to $linked.
@@ -45,7 +43,15 @@ class Create extends Property
             $this->setLinked($linked);
         }
     }
-    
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "CREATE PROPERTY :Class.:Property :Type :Linked";
+    }
+
     public function setLinked($linked)
     {
         $this->setToken('Linked', $linked);

--- a/src/Congow/Orient/Query/Command/Property/Drop.php
+++ b/src/Congow/Orient/Query/Command/Property/Drop.php
@@ -24,5 +24,11 @@ use Congow\Orient\Query\Command\Property;
 
 class Drop extends Property
 {
-    const SCHEMA = "DROP PROPERTY :Class.:Property";
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "DROP PROPERTY :Class.:Property";
+    }
 }

--- a/src/Congow/Orient/Query/Command/Reference/Find.php
+++ b/src/Congow/Orient/Query/Command/Reference/Find.php
@@ -25,8 +25,6 @@ use Congow\Orient\Query\Command;
 
 class Find extends Command implements FindInterface
 {
-    const SCHEMA = "FIND REFERENCES :Rid :ClassList";
-
     /**
      * Creates a new object, setting the $rid to lookup.
      *
@@ -37,6 +35,14 @@ class Find extends Command implements FindInterface
         parent::__construct();
 
         $this->setRid($rid);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "FIND REFERENCES :Rid :ClassList";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Select.php
+++ b/src/Congow/Orient/Query/Command/Select.php
@@ -26,10 +26,6 @@ use Congow\Orient\Contract\Query\Command\Select as SelectInterface;
 
 class Select extends Command implements SelectInterface
 {
-    const SCHEMA =
-        "SELECT :Projections FROM :Target :Where :Between :OrderBy :Limit :Range"
-    ;
-
     /**
      * Builds a Select object injecting the $target into the FROM clause.
      *
@@ -42,6 +38,14 @@ class Select extends Command implements SelectInterface
         if ($target) {
             $this->setTokenValues('Target', $target);
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "SELECT :Projections FROM :Target :Where :Between :OrderBy :Limit :Range";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Truncate/Cluster.php
+++ b/src/Congow/Orient/Query/Command/Truncate/Cluster.php
@@ -23,6 +23,12 @@ use Congow\Orient\Query\Command\Truncate;
 
 class Cluster extends Truncate
 {
-    const SCHEMA = "TRUNCATE CLUSTER :Name";
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "TRUNCATE CLUSTER :Name";
+    }
 }
 

--- a/src/Congow/Orient/Query/Command/Truncate/OClass.php
+++ b/src/Congow/Orient/Query/Command/Truncate/OClass.php
@@ -23,6 +23,12 @@ use Congow\Orient\Query\Command\Truncate;
 
 class OClass extends Truncate
 {
-    const SCHEMA = "TRUNCATE CLASS :Name";
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "TRUNCATE CLASS :Name";
+    }
 }
 

--- a/src/Congow/Orient/Query/Command/Truncate/Record.php
+++ b/src/Congow/Orient/Query/Command/Truncate/Record.php
@@ -23,15 +23,21 @@ use Congow\Orient\Query\Command;
 
 class Record extends Command
 {
-    const SCHEMA = "TRUNCATE RECORD :Rid";
-    
     public function __construct($rid)
     {
         parent::__construct();
         
         $this->setToken('Rid', $rid);
     }
-    
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "TRUNCATE RECORD :Rid";
+    }
+
     protected function getTokenFormatters()
     {
         return array_merge(parent::getTokenFormatters(), array(

--- a/src/Congow/Orient/Query/Command/Update.php
+++ b/src/Congow/Orient/Query/Command/Update.php
@@ -24,10 +24,6 @@ use Congow\Orient\Contract\Query\Command\Update as UpdateInterface;
 
 class Update extends Command implements UpdateInterface
 {
-    const SCHEMA =
-        "UPDATE :Class SET :Updates :Where"
-    ;
-
     /**
      * Builds a new statement, setting the $class.
      *
@@ -38,6 +34,14 @@ class Update extends Command implements UpdateInterface
         parent::__construct();
 
         $this->setToken('Class', $class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "UPDATE :Class SET :Updates :Where";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Update/Add.php
+++ b/src/Congow/Orient/Query/Command/Update/Add.php
@@ -24,10 +24,6 @@ use Congow\Orient\Query\Command\Update;
 
 class Add extends Update
 {
-    const SCHEMA =
-        "UPDATE :Class ADD :RidUpdates :Where"
-    ;
-
     /**
      * Builds a new statement setting the $values in the given $class.
      * You can $append the values.
@@ -41,6 +37,14 @@ class Add extends Update
         parent::__construct($class);
 
         $this->setTokenValues('RidUpdates', $values, $append);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "UPDATE :Class ADD :RidUpdates :Where";
     }
 
     /**

--- a/src/Congow/Orient/Query/Command/Update/Put.php
+++ b/src/Congow/Orient/Query/Command/Update/Put.php
@@ -24,10 +24,6 @@ use Congow\Orient\Query\Command\Update;
 
 class Put extends Update
 {
-    const SCHEMA =
-        "UPDATE :Class PUT :Updates :Where"
-    ;
-
     /**
      * Creates a new statement assigning the $values to update in the given
      * $class.
@@ -43,7 +39,15 @@ class Put extends Update
 
         $this->setTokenValues('Updates', $values, $append);
     }
-    
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "UPDATE :Class PUT :Updates :Where";
+    }
+
     /**
      * Returns the formatters for this query tokens
      *

--- a/src/Congow/Orient/Query/Command/Update/Remove.php
+++ b/src/Congow/Orient/Query/Command/Update/Remove.php
@@ -23,10 +23,6 @@ use Congow\Orient\Query\Command\Update;
 
 class Remove extends Update
 {
-    const SCHEMA =
-        "UPDATE :Class REMOVE :RidUpdates :Where"
-    ;
-
     /**
      * Builds a new statement setting the $values to remove in the given $class.
      * The values to remove can be appended with the $append parameter.
@@ -41,7 +37,15 @@ class Remove extends Update
 
         $this->setTokenValues('RidUpdates', $values, $append);
     }
-    
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSchema()
+    {
+        return "UPDATE :Class REMOVE :RidUpdates :Where";
+    }
+
     /**
      * Returns the formatters for this query tokens
      *

--- a/test/Query/Command/CredentialTest.php
+++ b/test/Query/Command/CredentialTest.php
@@ -16,7 +16,10 @@ use Congow\Orient\Query\Command\Credential;
 
 class CredentialStub extends Credential
 {
-    const SCHEMA = "STUB :Permission ON :Resource TO :Role";
+    protected function getSchema()
+    {
+        return "STUB :Permission ON :Resource TO :Role";
+    }
 }
 
 class CredentialTest extends TestCase

--- a/test/Query/CommandTest.php
+++ b/test/Query/CommandTest.php
@@ -17,12 +17,18 @@ use Congow\Orient\Formatter\Query as Formatter;
 
 class StubCommand extends Query\Command
 {
-    const SCHEMA = ":Target :Where";
+    protected function getSchema()
+    {
+        return ":Target :Where";
+    }
 }
 
 class StubExceptionedCommand extends Query\Command
 {
-    const SCHEMA = ":NotFoundToken";
+    protected function getSchema()
+    {
+        return ":NotFoundToken";
+    }
 }
 
 class Command extends TestCase
@@ -76,7 +82,8 @@ class Command extends TestCase
 
     public function testTheCommandTokensAreValid()
     {
-        $this->assertTokens(array(':Target' => array(), ':Where' => array()), StubCommand::getTokens());
+        $command = new StubCommand();
+        $this->assertTokens(array(':Target' => array(), ':Where' => array()), $command->getTokens());
     }
 
     public function testYouCanResetAllTheWheresOfACommand()

--- a/test/QueryTest.php
+++ b/test/QueryTest.php
@@ -484,7 +484,8 @@ class QueryTest extends TestCase
 
     public function testTokens()
     {
-        $this->assertCommandGives(Select::getTokens(), $this->query->getTokens());
+        $select = new Select();
+        $this->assertCommandGives($select->getTokens(), $this->query->getTokens());
     }
     
     public function testTruncatingAClass()


### PR DESCRIPTION
I'm opening a pull request to start discussing this change just because it was easy enough to change the related code, but I'm still not sure if I'm missing some reasoning behind the current code.

I was wondering why we use a constant instead of an instance method to return the schema of a query, I don't think we even need to have it public or defined in the underlying interface since it is purely an implementation detail of the `Congow\Orient\Query\Command` abstract class.
