### PR TITLE
Add links to travis-ci and stillmaintained pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # OrientDB PHP Library
 
-![project status](http://stillmaintained.com/odino/Orient.png)
-
-![Build Status](https://secure.travis-ci.org/congow/Orient.png?branch=master)
+[![project status](http://stillmaintained.com/odino/Orient.png)](http://stillmaintained.com/congow/Orient)
+[![Build Status](https://secure.travis-ci.org/congow/Orient.png?branch=master)](http://secure.travis-ci.org/congow/Orient)
 
 ## What's Orient?
 


### PR DESCRIPTION
I'm used to clicking travis-ci badge when I want to see the tests. :)
