### PR TITLE
fixed bug where 2 requests with different methods would trigger 2 reques...

### DIFF
--- a/src/Doctrine/OrientDB/Binding/Client/Http/CurlClient.php
+++ b/src/Doctrine/OrientDB/Binding/Client/Http/CurlClient.php
@@ -91,6 +91,7 @@ class CurlClient
         curl_setopt_array($this->curl, array(
             CURLOPT_URL => $location,
             CURLOPT_COOKIE => $this->getRequestCookies(),
+            CURLOPT_CUSTOMREQUEST => $method,
         ));
 
         if (!$response = curl_exec($this->curl)) {


### PR DESCRIPTION
...ts with the same HTTP method

@nrk superweird, I have this code:

```
    public function execute(InputInterface $input, OutputInterface $output)
    {
        $databaseName   = sprintf("sharah_%s", $input->getOption('env'));
        $orientdb       = $this->getOrientDB();

        $output->writeln(sprintf('<info>Preparing to recreate database "%s"</info>', $databaseName));
        $databases = $this->listDatabases($output);

        if (in_array($databaseName, $databases)) {
            $output->writeln(sprintf('<info>the database "%s" exists, will be deleted</info>', $databaseName));
            $orientdb->deleteDatabase($databaseName);
            $output->writeln(sprintf('<info>deleted database "%s"</info>', $databaseName));
        } else {
            $output->writeln(sprintf('<info>database "%s" was not found, will be created from scratch</info>', $databaseName));
        }

        $output->writeln(sprintf('<info>creating database "%s"</info>', $databaseName));

        $orientdb->createDatabase($databaseName);
        $output->writeln(sprintf('<info>database "%s" was succesfully created</info>', $databaseName));

        $this->listDatabases($output);
    }

    protected function listDatabases(OutputInterface $output)
    {
        $databases = $this->getOrientDB()->listDatabases()->getData()->databases;

        $output->writeln(sprintf('<info>Found (%d) databases:</info>', count($databases)));

        foreach ($databases as $database) {
            $output->writeln(sprintf('<comment> * "%s"</comment>', $database));
        }

        return $databases;
    }

    /**
     * @return HttpBinding
     */
    public function getOrientDB()
    {
        return $this->getContainer()->get('orientdb.binding');
    }
```

When the database is already there, the second call to `listDatabases` would be executes as a `DELETE` by the HTTP binding:

```
2014-01-11 01:01:36:209 WARN ->127.0.0.1: Command not found: DELETE.listDatabases [ONetworkProtocolHttpDb]
```
