### PR TITLE
Fixed travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.5
 before_script:
   - ./bin/initialize-dependencies.sh
-  - sh -c ./bin/initialize-ci.sh 1.7.7
+  - ./bin/initialize-ci.sh 1.7.7
   - php ./test/Integration/fixtures/load.php
 script: bin/phpunit --group __nogroup__,integration
 notifications:

--- a/bin/odb-shared.sh
+++ b/bin/odb-shared.sh
@@ -55,7 +55,7 @@ odb_download_composer () {
 odb_download_server () {
   #http://www.orientdb.org/portal/function/portal/download/robot-php-#@travi-ci.com/%20/%20/%20/%20/unknown/orientdb-community-#.#.#.tar.gz/false/false/mac
 
-  DOWN_USER=robot-php-${TRAVIS_JOB_ID}@travi-ci.com
+  DOWN_USER=robot-php-`date +%s`@travi-ci.com
   ODB_VERSION=$1
   CI_DIR=$2
 


### PR DESCRIPTION
A static user can now exceed limitations for downloads. I added the travis job id as it was the simplest way and I wasn't sure if it was worth to further complicate the script for a generic solution.

Also I'm not sure why [the os was specified as mac](https://github.com/doctrine/orientdb-odm/blob/master/bin/odb-shared.sh#L70). There is a `linux` and a `multi` tag available as well, let me know if you are okay with changing it.

Lastly, is there any reason why not bump up the tested version to 1.7.10? 
