### PR TITLE
Feature unit of work

### DIFF
--- a/bin/initialize-ci.sh
+++ b/bin/initialize-ci.sh
@@ -33,5 +33,5 @@ echo "--- Starting an instance of OrientDB ---"
 sh -c $ODB_LAUNCHER </dev/null &>/dev/null &
 
 # Wait a bit for OrientDB to finish the initialization phase.
-sleep 5
+sleep 10
 printf "\n=== The CI environment has been initialized ===\n"

--- a/ci-stuff/orientdb-server-config.xml
+++ b/ci-stuff/orientdb-server-config.xml
@@ -4,6 +4,7 @@
         <handler class="com.orientechnologies.orient.server.handler.OServerSideScriptInterpreter">
             <parameters>
                 <parameter name="enabled" value="true" />
+                <parameter name="allowedLanguages" value="SQL,Javascript"/>
             </parameters>
         </handler>
     </handlers>

--- a/src/Doctrine/ODM/OrientDB/Caster/AbstractCaster.php
+++ b/src/Doctrine/ODM/OrientDB/Caster/AbstractCaster.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Doctrine\ODM\OrientDB\Caster;
+
+
+abstract class AbstractCaster implements CasterInterface
+{
+    protected $dateClass   = '\DateTime';
+    protected $value;
+    protected $properties   = array();
+
+    const SHORT_LIMIT       = 32767;
+    const LONG_LIMIT        = 9223372036854775807;
+    const BYTE_MAX_VALUE    = 127;
+    const BYTE_MIN_VALUE    = -128;
+    const MISMATCH_MESSAGE  = 'trying to cast "%s" as %s';
+
+
+    /**
+     * Sets the internal value to work with.
+     *
+     * @param mixed $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Assigns the class used to cast dates and datetimes.
+     * If the $class is a subclass of \DateTime, it uses it, it uses \DateTime
+     * otherwise.
+     *
+     * @param string $class
+     */
+    protected function assignDateClass($class)
+    {
+        $refClass = new \ReflectionClass($class);
+
+        if (!($refClass->getName() === 'DateTime' || $refClass->isSubclassOf('DateTime'))) {
+            throw new \InvalidArgumentException("The class used to cast DATE and DATETIME values must be derived from DateTime.");
+        }
+
+        $this->dateClass = $class;
+    }
+
+    /**
+     * Returns the class used to cast date and datetimes.
+     *
+     * @return string
+     */
+    protected function getDateClass()
+    {
+        return $this->dateClass;
+    }
+
+    /**
+     * Defines properties that can be internally used by the caster.
+     *
+     * @param string $key
+     * @param mixed  $property
+     */
+    public function setProperty($key, $property)
+    {
+        $this->properties[$key] = $property;
+    }
+
+    /**
+     * Returns a property of the Caster, given its $key.
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    protected function getProperty($key)
+    {
+        return isset($this->properties[$key]) ? $this->properties[$key] : null;
+    }
+
+    /**
+     * Throws an exception whenever $value can not be casted as $expectedType.
+     */
+    protected function raiseMismatch($expectedType)
+    {
+        $value = $this->value;
+
+        if (is_object($value)) {
+            $value = get_class($value);
+        } elseif (is_array($value)) {
+            $value = implode(',', $value);
+        }
+
+        throw new CastingMismatchException(sprintf(self::MISMATCH_MESSAGE, $value, $expectedType));
+    }
+} 

--- a/src/Doctrine/ODM/OrientDB/Caster/CasterInterface.php
+++ b/src/Doctrine/ODM/OrientDB/Caster/CasterInterface.php
@@ -145,16 +145,7 @@ interface CasterInterface
      */
     public function castLong();
 
-    /**
-     * Casts the current value into an integer verifying it belongs to a certain
-     * range ( -$limit < $value > + $limit ).
-     *
-     * @param integer   $limit
-     * @param string    $type
-     * @return integer
-     * @throws \Doctrine\OrientDB\Overflow
-     */
-    public function castInBuffer($limit, $type);
+
 
     /**
      * Casts the value to string.

--- a/src/Doctrine/ODM/OrientDB/Caster/ReverseCaster.php
+++ b/src/Doctrine/ODM/OrientDB/Caster/ReverseCaster.php
@@ -3,18 +3,8 @@
 namespace Doctrine\ODM\OrientDB\Caster;
 
 
-use Doctrine\ODM\OrientDB\Persistence\DocumentPersister;
-
 class ReverseCaster extends AbstractCaster
 {
-    protected $inflector;
-
-    public function __construct(DocumentPersister $persister)
-    {
-        $this->persister = $persister;
-    }
-
-
     /**
      * Casts the value to string.
      *

--- a/src/Doctrine/ODM/OrientDB/Caster/ReverseCaster.php
+++ b/src/Doctrine/ODM/OrientDB/Caster/ReverseCaster.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Doctrine\ODM\OrientDB\Caster;
+
+
+use Doctrine\ODM\OrientDB\Persistence\DocumentPersister;
+
+class ReverseCaster extends AbstractCaster
+{
+    protected $inflector;
+
+    public function __construct(DocumentPersister $persister)
+    {
+        $this->persister = $persister;
+    }
+
+
+    /**
+     * Casts the value to string.
+     *
+     * @return string
+     */
+    public function castString()
+    {
+        if (is_string($this->value)) {
+            return $this->value;
+        }
+
+        $this->raiseMismatch('string');
+    }
+
+    /**
+     * Casts the value to a short.
+     *
+     * @return mixed
+     */
+    public function castShort()
+    {
+        return $this->castNumeric();
+    }
+
+    /**
+     * Casts the value to a long.
+     *
+     * @return mixed
+     */
+    public function castLong()
+    {
+        return $this->castNumeric();
+    }
+
+    /**
+     * Casts the given $value to boolean.
+     *
+     * @return boolean
+     */
+    public function castBoolean()
+    {
+        return (bool) $this->value;
+    }
+
+    /**
+     * Casts the given $value to a binary.
+     *
+     * @return string
+     */
+    public function castBinary()
+    {
+        if ("data:;base64," === substr($this->value, 0, 13)) {
+            return substr($this->value, 13);
+        }
+
+        $this->raiseMisMatch('binary');
+    }
+
+    /**
+     * Casts the given $value to a byte.
+     *
+     * @throws CastingMismatchException
+     * @return mixed
+     */
+    public function castByte()
+    {
+        return $this->castNumeric();
+    }
+
+    /**
+     * Casts the given $value to a DateTime object.
+     * If the value was stored as a timestamp, it sets the value to the DateTime
+     * object via the setTimestamp method.
+     *
+     * @return \DateTime
+     */
+    public function castDate()
+    {
+        $dateClass = $this->getDateClass();
+        if ($this->value instanceof $dateClass) {
+            return $this->value->getTimestamp() * 1000; //ODB takes milliseconds accuracy
+        }
+
+        $this->raiseMismatch('\DateTime');
+    }
+
+    /**
+     * Casts the given $value to a DateTime object.
+     *
+     * @return \DateTime
+     */
+    public function castDateTime()
+    {
+        return $this->castDate();
+    }
+
+    /**
+     * Casts the internal value to an integer cmprehended between a range of
+     * accepted integers.
+     *
+     * @return integer
+     */
+    public function castDecimal()
+    {
+        return $this->castNumeric();
+    }
+
+    /**
+     * Casts the given $value to a double (well... float).
+     *
+     * @return float
+     */
+    public function castDouble()
+    {
+        return $this->castFloat();
+    }
+
+    /**
+     * Given an embedded record, it uses the manager to hydrate it.
+     *
+     * @return mixed
+     */
+    public function castEmbedded()
+    {
+        throw new \Exception('to be implemented');
+    }
+
+    /**
+     * Casts a list of embedded entities
+     *
+     * @return Array
+     */
+    public function castEmbeddedList()
+    {
+        throw new \Exception('to be implemented');
+    }
+
+    /**
+     * Casts a map (key-value preserved) of embedded entities
+     *
+     * @return Array
+     */
+    public function castEmbeddedMap()
+    {
+        throw new \Exception('to be implemented');
+
+    }
+
+    /**
+     * Casts a set of embedded entities
+     *
+     * @return Array
+     */
+    public function castEmbeddedSet()
+    {
+        throw new \Exception('to be implemented');
+
+    }
+
+    public function castLink()
+    {
+        throw new \Exception('to be implemented');
+    }
+
+    public function castLinkSet()
+    {
+        throw new \Exception('to be implemented');
+    }
+
+    public function castLinkList()
+    {
+        throw new \Exception('to be implemented');
+    }
+
+    public function castLinkMap()
+    {
+        throw new \Exception('to be implemented');
+    }
+
+    /**
+     * Casts the value to a float.
+     *
+     * @return float
+     */
+    public function castFloat()
+    {
+        return $this->castNumeric();
+    }
+
+    /**
+     * Casts the value into an integer.
+     *
+     * @return integer
+     */
+    public function castInteger()
+    {
+        return $this->castNumeric();
+    }
+
+    /**
+     * Checks if the value is numeric, otherwise throws exception.
+     * ODB automatically transforms numeric values into the type specified,
+     * so there is no reason to cast them.
+     *
+     * @return int|string
+     * @throws CastingMismatchException
+     */
+    protected function castNumeric()
+    {
+        if (is_numeric($this->value)) {
+            return $this->value;
+        }
+
+        $this->raiseMismatch('integer');
+    }
+} 

--- a/src/Doctrine/ODM/OrientDB/Configuration.php
+++ b/src/Doctrine/ODM/OrientDB/Configuration.php
@@ -24,7 +24,7 @@ class Configuration
     private $cache;
     private $annotationReader;
 
-    private $suppoertedPersisterStrategies = array('sql_batch');
+    private $supportedPersisterStrategies = array('sql_batch');
 
     public function __construct(array $options = array())
     {
@@ -112,8 +112,8 @@ class Configuration
     {
         if (isset($this->options['persister_strategy'])) {
             $strategy = $this->options['persister_strategy'];
-            if (! in_array($strategy, $this->suppoertedPersisterStrategies)) {
-                throw ConfigurationException::invalidPersisterStrategy($strategy, $this->suppoertedPersisterStrategies);
+            if (! in_array($strategy, $this->supportedPersisterStrategies)) {
+                throw ConfigurationException::invalidPersisterStrategy($strategy, $this->supportedPersisterStrategies);
             }
         } else {
             $strategy = 'sql_batch';

--- a/src/Doctrine/ODM/OrientDB/Configuration.php
+++ b/src/Doctrine/ODM/OrientDB/Configuration.php
@@ -24,6 +24,8 @@ class Configuration
     private $cache;
     private $annotationReader;
 
+    private $suppoertedPersisterStrategies = array('sql_batch');
+
     public function __construct(array $options = array())
     {
         $defaults = array(
@@ -104,5 +106,19 @@ class Configuration
         }
 
         return $this->annotationReader;
+    }
+
+    public function getPersisterStrategy()
+    {
+        if (isset($this->options['persister_strategy'])) {
+            $strategy = $this->options['persister_strategy'];
+            if (! in_array($strategy, $this->suppoertedPersisterStrategies)) {
+                throw ConfigurationException::invalidPersisterStrategy($strategy, $this->suppoertedPersisterStrategies);
+            }
+        } else {
+            $strategy = 'sql_batch';
+        }
+
+        return $strategy;
     }
 }

--- a/src/Doctrine/ODM/OrientDB/ConfigurationException.php
+++ b/src/Doctrine/ODM/OrientDB/ConfigurationException.php
@@ -9,4 +9,9 @@ class ConfigurationException extends \Exception
     {
         return new self(sprintf('%s must be set in the configuration.', $key));
     }
+
+    public static function invalidPersisterStrategy($strategy, array $accepted)
+    {
+        return new self(sprintf('You have specified an invalid persister strategy (%s), accepted strategies are %s.', $strategy, implode(', ', $accepted)));
+    }
 }

--- a/src/Doctrine/ODM/OrientDB/Manager.php
+++ b/src/Doctrine/ODM/OrientDB/Manager.php
@@ -33,7 +33,7 @@ use Doctrine\OrientDB\Binding\BindingInterface;
 use Doctrine\OrientDB\Query\Query;
 use Doctrine\OrientDB\Query\Validator\Rid as RidValidator;
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory as MetadataFactory;
+use Doctrine\ODM\OrientDB\Mapper\ClassMetadataFactory as MetadataFactory;
 
 class Manager implements ObjectManager
 {
@@ -173,11 +173,11 @@ class Manager implements ObjectManager
     /**
      * @todo to implement/test
      *
-     * @param \stdClass $object
+     * @param $document
      */
-    public function flush()
+    public function flush($document = null)
     {
-        throw new \Exception;
+        $this->getUnitOfWork()->commit($document);
     }
 
     /**
@@ -185,7 +185,7 @@ class Manager implements ObjectManager
      *
      * @param   string $class
      *
-     * @return  \Doctrine\Common\Persistence\Mapping\ClassMetadata
+     * @return \Doctrine\ODM\OrientDB\Mapper\ClassMetadata
      */
     public function getClassMetadata($class)
     {
@@ -280,11 +280,11 @@ class Manager implements ObjectManager
     /**
      * @todo to implement/test
      *
-     * @param \stdClass $object
+     * @param $document
      */
-    public function persist($object)
+    public function persist($document)
     {
-        throw new \Exception();
+        $this->getUnitOfWork()->attach($document);
     }
 
     /**

--- a/src/Doctrine/ODM/OrientDB/Manager.php
+++ b/src/Doctrine/ODM/OrientDB/Manager.php
@@ -110,7 +110,7 @@ class Manager implements ObjectManager
      */
     public function getReference($rid)
     {
-        return $this->getUnitOfWork()->getProxyFor(new Rid($rid), true);
+        return $this->getUnitOfWork()->getProxy(new Rid($rid), true);
     }
 
     /**
@@ -137,7 +137,7 @@ class Manager implements ObjectManager
         $rid       = $validator->check($rid);
 
         try {
-            return $this->getUnitOfWork()->getProxyFor(new Rid($rid), false, $fetchPlan);
+            return $this->getUnitOfWork()->getProxy(new Rid($rid), false, $fetchPlan);
         } catch (OClassNotFoundException $e) {
             throw $e;
         } catch (CastingMismatchException $e) {
@@ -167,7 +167,7 @@ class Manager implements ObjectManager
      */
     public function findRecords(array $rids, $lazy = false, $fetchPlan = '*:0')
     {
-        return $this->getUnitOfWork()->getCollectionFor($rids, $lazy, $fetchPlan);
+        return $this->getUnitOfWork()->getCollection($rids, $lazy, $fetchPlan);
     }
 
     /**

--- a/src/Doctrine/ODM/OrientDB/Manager.php
+++ b/src/Doctrine/ODM/OrientDB/Manager.php
@@ -290,11 +290,11 @@ class Manager implements ObjectManager
     /**
      * @todo to implement/test
      *
-     * @param \stdClass $object
+     * @param $object
      */
     public function remove($object)
     {
-        throw new \Exception();
+        $this->getUnitOfWork()->markForRemoval($object);
     }
 
     /**
@@ -308,13 +308,19 @@ class Manager implements ObjectManager
     }
 
     /**
-     * @todo to implement/test
+     * If an object is given, it is cleared from the uow,
+     * if not an entire new uow is created.
      *
-     * @param \stdClass $object
+     * @param $object
      */
     public function clear($object = null)
     {
-        throw new \Exception();
+        if ($object) {
+            $this->uow->clear($object);
+        }
+
+        unset($this->uow);
+        $this->uow = new UnitOfWork($this);
     }
 
     /**

--- a/src/Doctrine/ODM/OrientDB/Mapper/Annotations/Document.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/Annotations/Document.php
@@ -25,23 +25,4 @@ namespace Doctrine\ODM\OrientDB\Mapper\Annotations;
 class Document extends \Doctrine\Common\Annotations\Annotation
 {
     public $class;
-
-    /**
-     * Given a $Doctrine\OrientDBClass, checks wheter this annotation matches it.
-     *
-     * @param  string   $Doctrine\OrientDBClass
-     * @return boolean
-     */
-    public function hasMatchingClass($orientClass)
-    {
-        $classes = explode(',', $this->class);
-
-        foreach ($classes as $class) {
-            if ($class === $orientClass) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
@@ -344,7 +344,7 @@ class ClassMetadata implements DoctrineMetadata
 
     /**
      * Given a $property and its $value, sets that property on the given $document
-     * by using a closure.
+     * by using a closures if available, otherwise fall back to reflection.
      *
      * @param mixed $document
      * @param string $property
@@ -352,12 +352,15 @@ class ClassMetadata implements DoctrineMetadata
      */
     public function setDocumentValue($document, $property, $value)
     {
-        $setter = \Closure::bind(function ($document, $property, $value) {
-                $document->$property = $value;
-            }, null, $document
-        );
-
-        $setter($document, $property, $value);
+        if (method_exists('\Closure', 'bind')) {
+            $setter = \Closure::bind(function ($document, $property, $value) {
+                    $document->$property = $value;
+                }, null, $document
+            );
+            $setter($document, $property, $value);
+        } else {
+            $this->getReflectionClass()->getProperty($property)->setValue($document, $value);
+        }
     }
 
     /**

--- a/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
@@ -359,7 +359,9 @@ class ClassMetadata implements DoctrineMetadata
             );
             $setter($document, $property, $value);
         } else {
-            $this->getReflectionClass()->getProperty($property)->setValue($document, $value);
+            $reflProperty = $this->getReflectionClass()->getProperty($property);
+            $reflProperty->setAccessible(true);
+            $reflProperty->setValue($document, $value);
         }
     }
 

--- a/src/Doctrine/ODM/OrientDB/Mapper/Hydration/Hydrator.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/Hydration/Hydrator.php
@@ -182,8 +182,8 @@ class Hydrator
          */
         if (isset($orientObject->{'@rid'})) {
             $rid = new Rid($orientObject->{'@rid'});
-            if ($this->getUnitOfWork()->hasProxyFor($rid)) {
-                $document = $this->getUnitOfWork()->getProxyFor($rid);
+            if ($this->getUnitOfWork()->hasProxy($rid)) {
+                $document = $this->getUnitOfWork()->getProxy($rid);
             } else {
                 $document = $this->getProxyFactory()->getProxy($class, array($metadata->getRidPropertyName() => $rid->getValue()));
             }

--- a/src/Doctrine/ODM/OrientDB/Mapper/MappingException.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/MappingException.php
@@ -23,4 +23,9 @@ class MappingException extends \Exception
     {
         return new self(sprintf('There is no cluster for %s.', $rid->getValue()));
     }
-} 
+
+    public static function noMappingForProperty($property, $class)
+    {
+        return new self(sprintf('The %s class has no mapping for %s property.', $class, $property));
+    }
+}

--- a/src/Doctrine/ODM/OrientDB/Persistence/ChangeSet.php
+++ b/src/Doctrine/ODM/OrientDB/Persistence/ChangeSet.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\ODM\OrientDB\Persistence;
+
+
+/**
+ * Class ChangeSet
+ *
+ * @package    Doctrine\ODM
+ * @subpackage OrientDB
+ * @author     Tamás Millián <tamas.millian@gmail.com>
+ */
+class ChangeSet
+{
+    private $updates;
+    private $inserts;
+
+    public function __construct(array $updates, array $inserts)
+    {
+        $this->updates = $updates;
+        $this->inserts = $inserts;
+    }
+
+    public function getUpdates()
+    {
+        return $this->updates;
+    }
+
+    public function getInserts()
+    {
+        return $this->inserts;
+    }
+} 

--- a/src/Doctrine/ODM/OrientDB/Persistence/ChangeSet.php
+++ b/src/Doctrine/ODM/OrientDB/Persistence/ChangeSet.php
@@ -14,20 +14,36 @@ class ChangeSet
 {
     private $updates;
     private $inserts;
+    private $removals;
 
-    public function __construct(array $updates, array $inserts)
+    public function __construct(array $updates, array $inserts, array $removals)
     {
         $this->updates = $updates;
         $this->inserts = $inserts;
+        $this->removals = $removals;
     }
 
-    public function getUpdates()
-    {
-        return $this->updates;
-    }
-
+    /**
+     * @return array
+     */
     public function getInserts()
     {
         return $this->inserts;
     }
-} 
+
+    /**
+     * @return array
+     */
+    public function getRemovals()
+    {
+        return $this->removals;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUpdates()
+    {
+        return $this->updates;
+    }
+}

--- a/src/Doctrine/ODM/OrientDB/Persistence/DocumentPersister.php
+++ b/src/Doctrine/ODM/OrientDB/Persistence/DocumentPersister.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Doctrine\ODM\OrientDB\Persistence;
+
+
+use Doctrine\Common\Util\Inflector;
+use Doctrine\ODM\OrientDB\Caster\ReverseCaster;
+use Doctrine\ODM\OrientDB\UnitOfWork;
+use Doctrine\OrientDB\Binding\HttpBindingInterface;
+
+/**
+ * Class DocumentPersister
+ *
+ * @package    Doctrine\ODM
+ * @subpackage OrientDB
+ * @author     Tamás Millián <tamas.millian@gmail.com>
+ */
+class DocumentPersister
+{
+    protected $metadataFactory;
+    protected $caster;
+    protected $binding;
+    protected $inflector;
+    protected $queryDocumentMap = array();
+
+    public function __construct(UnitOfWork $uow, Inflector $inflector)
+    {
+        $manager = $uow->getManager();
+        $this->metadataFactory = $manager->getMetadataFactory();
+        $this->binding = $manager->getBinding();
+        $this->inflector = $inflector;
+        $this->caster = new ReverseCaster($this);
+    }
+
+
+    /**
+     * Processes the changeSet and maps the RIDs back to new documents
+     * so it can be used in userland.
+     *
+     * @param ChangeSet $changeSet
+     *
+     * @throws \Exception
+     */
+    public function process(ChangeSet $changeSet)
+    {
+        $queryWriter = new QueryWriter();
+        foreach ($changeSet->getInserts() as $identifier => $insert) {
+            $metadata = $this->metadataFactory->getMetadataFor(get_class($insert['document']));
+            $fields = $this->getCastedFields($insert['changes']);
+            $position = $queryWriter->addInsertQuery($identifier, $metadata->getOrientClass(), $fields);
+            $this->queryDocumentMap[$position] = array('document' => $insert['document'], 'metadata' => $metadata);
+        }
+
+        if ($this->binding instanceof HttpBindingInterface) {
+            $batch = array(
+                'transaction' => true,
+                'operations' => array(
+                    array(
+                        'type' => 'script',
+                        'language' => 'sql',
+                        'script' => $queryWriter->getQueries()
+                    )
+                )
+            );
+            $results = $this->binding->batch(json_encode($batch))->getData()->result;
+
+
+        } else {
+            throw new \Exception('Only HttpBindingInterface is supported.');
+        }
+
+        // set the RID on the created documents
+        foreach ($results as $position => $result) {
+            $map = $this->queryDocumentMap[$position];
+            $document = $map['document'];
+            $metadata = $map['metadata'];
+
+            $metadata->setDocumentValue($document, $metadata->getRidPropertyName(), $result->{'@rid'});
+        }
+    }
+
+
+    /**
+     * Casts the fields and returns an array mapped fieldname => value
+     *
+     * @param array $changes
+     *
+     * @return array
+     */
+    protected function getCastedFields(array $changes)
+    {
+        $castedChanges = array();
+        foreach ($changes as $change) {
+            $castedChanges[$change['field']] = $this->castProperty($change['annotation'], $change['value']);
+        }
+
+        return $castedChanges;
+    }
+
+    /**
+     * Casts a value according to how it was annotated.
+     *
+     * @param  \Doctrine\ODM\OrientDB\Mapper\Annotations\Property  $annotation
+     * @param  mixed                                               $propertyValue
+     * @return mixed
+     */
+    protected function castProperty($annotation, $propertyValue)
+    {
+        $method = 'cast' . $this->inflector->camelize($annotation->type);
+
+        $this->caster->setValue($propertyValue);
+        $this->caster->setProperty('annotation', $annotation);
+
+        return $this->caster->$method();
+    }
+
+}

--- a/src/Doctrine/ODM/OrientDB/Persistence/PersisterInterface.php
+++ b/src/Doctrine/ODM/OrientDB/Persistence/PersisterInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\ODM\OrientDB\Persistence;
+
+
+interface PersisterInterface
+{
+    /**
+     * Processes the changeSet and maps the RIDs back to new documents
+     * so it can be used in userland.
+     *
+     * @param ChangeSet $changeSet
+     *
+     */
+    public function process(ChangeSet $changeSet);
+} 

--- a/src/Doctrine/ODM/OrientDB/Persistence/QueryWriter.php
+++ b/src/Doctrine/ODM/OrientDB/Persistence/QueryWriter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\ODM\OrientDB\Persistence;
+
+
+use Doctrine\ODM\OrientDB\Mapper\ClassMetadata;
+use Doctrine\ODM\OrientDB\Mapper\ClassMetadataFactory;
+
+/**
+ * Class QueryWriter
+ *
+ * @package    Doctrine\ODM
+ * @subpackage OrientDB
+ * @author     Tamás Millián <tamas.millian@gmail.com>
+ */
+class QueryWriter
+{
+    private $queries = array();
+
+    public function getQueries()
+    {
+        return $this->queries;
+    }
+
+    public function addInsertQuery($identifier, $class, array $fields, $cluster = null)
+    {
+        $query = "let %s = INSERT INTO %s%s SET %s";
+        $cluster = $cluster ? ' cluster '.$cluster : '';
+        $this->queries[] = sprintf($query, $identifier, $class, $cluster, $this->flattenFields($fields));
+
+        return count($this->queries)-1;
+    }
+
+    public function matchResultToQueries()
+    {
+
+    }
+
+    protected function flattenFields(array $fields)
+    {
+        $string = '';
+        foreach ($fields as $name => $value) {
+            $string .= sprintf('%s=%s,', $name, $this->escape($value));
+        }
+
+        return rtrim($string, ',');
+    }
+
+    protected function escape($value)
+    {
+        return is_string($value) ? "'$value'" : $value;
+    }
+}

--- a/src/Doctrine/ODM/OrientDB/Persistence/QueryWriter.php
+++ b/src/Doctrine/ODM/OrientDB/Persistence/QueryWriter.php
@@ -28,12 +28,23 @@ class QueryWriter
         $cluster = $cluster ? ' cluster '.$cluster : '';
         $this->queries[] = sprintf($query, $identifier, $class, $cluster, $this->flattenFields($fields));
 
+        // returned so we can map the rid to the document
         return count($this->queries)-1;
     }
 
-    public function matchResultToQueries()
+    public function addUpdateQuery($identifier, array $fields, $lock = 'DEFAULT')
     {
+        $query = "UPDATE %s SET %s LOCK %s";
+        $this->queries[] = sprintf($query, $identifier, $this->flattenFields($fields), $lock);
+    }
 
+    /**
+     * @TODO cover vertex/edge deletion
+     */
+    public function addDeleteQuery($identifier, $class, $lock = 'DEFAULT')
+    {
+        $query = "DELETE FROM %s WHERE @rid = %s LOCK %s";
+        $this->queries[] = sprintf($query, $class, $identifier, $lock);
     }
 
     protected function flattenFields(array $fields)

--- a/src/Doctrine/ODM/OrientDB/Persistence/SQLBatchPersister.php
+++ b/src/Doctrine/ODM/OrientDB/Persistence/SQLBatchPersister.php
@@ -15,7 +15,7 @@ use Doctrine\OrientDB\Binding\HttpBindingInterface;
  * @subpackage OrientDB
  * @author     Tamás Millián <tamas.millian@gmail.com>
  */
-class DocumentPersister
+class SQLBatchPersister implements PersisterInterface
 {
     protected $metadataFactory;
     protected $caster;
@@ -29,7 +29,7 @@ class DocumentPersister
         $this->metadataFactory = $manager->getMetadataFactory();
         $this->binding = $manager->getBinding();
         $this->inflector = $inflector;
-        $this->caster = new ReverseCaster($this);
+        $this->caster = new ReverseCaster();
     }
 
 

--- a/src/Doctrine/ODM/OrientDB/UnitOfWork.php
+++ b/src/Doctrine/ODM/OrientDB/UnitOfWork.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\OrientDB;
 use Doctrine\ODM\OrientDB\Collections\ArrayCollection;
 use Doctrine\ODM\OrientDB\Mapper\Hydration\Hydrator;
 use Doctrine\ODM\OrientDB\Persistence\ChangeSet;
-use Doctrine\ODM\OrientDB\Persistence\DocumentPersister;
+use Doctrine\ODM\OrientDB\Persistence\SQLBatchPersister;
 use Doctrine\ODM\OrientDB\Proxy\Proxy;
 use Doctrine\ODM\OrientDB\Types\Rid;
 use Doctrine\OrientDB\Query\Query;
@@ -46,7 +46,7 @@ class UnitOfWork
         }
 
         $changeSet = new ChangeSet($this->documentUpdates, $this->documentInserts);
-        $persister = new DocumentPersister($this, $this->getInflector());
+        $persister = $this->createPersister();
         $persister->process($changeSet);
 
         $this->documentInserts
@@ -279,4 +279,12 @@ class UnitOfWork
     {
         return $this->getManager()->getInflector();
     }
-} 
+
+    protected function createPersister()
+    {
+        $strategy = $this->manager->getConfiguration()->getPersisterStrategy();
+        if ('sql_batch' === $strategy) {
+            return new SQLBatchPersister($this, $this->getInflector());
+        }
+    }
+}

--- a/src/Doctrine/ODM/OrientDB/UnitOfWork.php
+++ b/src/Doctrine/ODM/OrientDB/UnitOfWork.php
@@ -73,7 +73,7 @@ class UnitOfWork
         return true;
     }
 
-    public function hasProxyFor(Rid $rid)
+    public function hasProxy(Rid $rid)
     {
         return isset($this->proxies[$rid->getValue()]);
     }
@@ -85,9 +85,9 @@ class UnitOfWork
      *
      * @return Proxy
      */
-    public function getProxyFor(Rid $rid, $lazy = true, $fetchPlan = null)
+    public function getProxy(Rid $rid, $lazy = true, $fetchPlan = null)
     {
-        if (! $this->hasProxyFor($rid)) {
+        if (! $this->hasProxy($rid)) {
             if ($lazy) {
                 $proxy = $this->getHydrator()->hydrateRid($rid);
             } else {
@@ -107,12 +107,12 @@ class UnitOfWork
      *
      * @return ArrayCollection|null
      */
-    public function getCollectionFor(array $rids, $lazy = true, $fetchPlan = null)
+    public function getCollection(array $rids, $lazy = true, $fetchPlan = null)
     {
         if ($lazy) {
             $proxies = array();
             foreach ($rids as $rid) {
-                $proxies[] = $this->getProxyFor(new Rid($rid), $lazy);
+                $proxies[] = $this->getProxy(new Rid($rid), $lazy);
             }
 
             return new ArrayCollection($proxies);

--- a/src/Doctrine/OrientDB/Binding/HttpBinding.php
+++ b/src/Doctrine/OrientDB/Binding/HttpBinding.php
@@ -383,6 +383,16 @@ class HttpBinding implements HttpBindingInterface
     /**
      * {@inheritdoc}
      */
+    public function batch($batch, $database = null)
+    {
+        $location = $this->getLocation('batch', $database ? :$this->database);
+
+        return $this->adapter->request('POST', $location, array(), $batch);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setAuthentication($username = null, $password = null)
     {
         $this->adapter->setAuthentication($username, $password);

--- a/src/Doctrine/OrientDB/Binding/HttpBindingInterface.php
+++ b/src/Doctrine/OrientDB/Binding/HttpBindingInterface.php
@@ -194,6 +194,18 @@ interface HttpBindingInterface extends BindingInterface
      */
     public function deleteDocument($rid, $version = null, $database = null);
 
+
+    /**
+     * Sends a batch to the database.
+     *
+     * @param      $batch
+     * @param null $database
+     *
+     * @return \Doctrine\OrientDB\Binding\Adapter\CurlClientAdapterResult|\Doctrine\OrientDB\Binding\BindingResultInterface
+     */
+    public function batch($batch, $database = null);
+
+
     /**
      * Sets the username and password used to authenticate to the server.
      *

--- a/test/Doctrine/ODM/OrientDB/Document/Stub/Contact/Address.php
+++ b/test/Doctrine/ODM/OrientDB/Document/Stub/Contact/Address.php
@@ -5,7 +5,7 @@ namespace test\Doctrine\ODM\OrientDB\Document\Stub\Contact;
 use Doctrine\ODM\OrientDB\Mapper\Annotations as ODM;
 
 /**
-* @ODM\Document(class="Address,ForeignAddress")
+* @ODM\Document(class="Address")
 */
 class Address
 {

--- a/test/Doctrine/ODM/OrientDB/Document/Stub/Contact/ForeignAddress.php
+++ b/test/Doctrine/ODM/OrientDB/Document/Stub/Contact/ForeignAddress.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace test\Doctrine\ODM\OrientDB\Document\Stub\Contact;
+
+use Doctrine\ODM\OrientDB\Mapper\Annotations as ODM;
+
+/**
+ * @ODM\Document(class="ForeignAddress")
+ */
+class ForeignAddress extends Address
+{
+
+} 

--- a/test/Doctrine/ODM/OrientDB/Integration/ManagerTest.php
+++ b/test/Doctrine/ODM/OrientDB/Integration/ManagerTest.php
@@ -228,4 +228,5 @@ class ManagerTest extends TestCase
         $this->assertInternalType('bool', $results);
         $this->assertTrue($results);
     }
+
 }

--- a/test/Doctrine/ODM/OrientDB/Integration/PersistenceTest.php
+++ b/test/Doctrine/ODM/OrientDB/Integration/PersistenceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace test\Doctrine\ODM\OrientDB\Integration;
+
+
+use test\Integration\Document\Country;
+use test\PHPUnit\TestCase;
+
+class PersistenceTest extends TestCase
+{
+    protected $manager;
+
+    protected function setUp()
+    {
+        $this->manager = $this->createManager();
+    }
+
+    public function testPersistSingleDocument()
+    {
+        $document = new Country();
+        $document->name = 'SinglePersistTest';
+
+        $this->manager->persist($document);
+        $this->manager->flush();
+
+        $this->assertNotNull($document->rid);
+
+        $proxy = $this->manager->find($document->rid);
+        $this->assertEquals('SinglePersistTest', $proxy->name);
+    }
+} 

--- a/test/Doctrine/ODM/OrientDB/Integration/PersistenceTest.php
+++ b/test/Doctrine/ODM/OrientDB/Integration/PersistenceTest.php
@@ -17,7 +17,7 @@ class PersistenceTest extends TestCase
 
     public function testPersistSingleDocument()
     {
-        $document = new Country();
+        $document       = new Country();
         $document->name = 'SinglePersistTest';
 
         $this->manager->persist($document);

--- a/test/Doctrine/ODM/OrientDB/Integration/PersistenceTest.php
+++ b/test/Doctrine/ODM/OrientDB/Integration/PersistenceTest.php
@@ -15,17 +15,53 @@ class PersistenceTest extends TestCase
         $this->manager = $this->createManager();
     }
 
-    public function testPersistSingleDocument()
+    public function testPersistDocument()
     {
         $document       = new Country();
         $document->name = 'SinglePersistTest';
 
         $this->manager->persist($document);
         $this->manager->flush();
-
+        $this->manager->clear();
         $this->assertNotNull($document->rid);
 
         $proxy = $this->manager->find($document->rid);
         $this->assertEquals('SinglePersistTest', $proxy->name);
+
+        return $document->rid;
+    }
+
+    /**
+     * @depends testPersistDocument
+     * @param $rid
+     */
+    public function testUpdateDocument($rid)
+    {
+        $document = $this->manager->find($rid);
+        $document->name = 'SingleUpdateTest';
+
+        unset($document);
+        $this->manager->flush();
+        $this->manager->clear();
+
+        $proxy = $this->manager->find($rid);
+        $this->assertEquals('SingleUpdateTest', $proxy->name);
+
+        return $rid;
+    }
+
+    /**
+     * @depends testUpdateDocument
+     * @param $rid
+     */
+    public function testDeleteDocument($rid)
+    {
+        $document = $this->manager->find($rid);
+        $this->manager->remove($document);
+        $this->manager->flush();
+        unset($document);
+        $this->manager->clear();
+
+        $this->assertNull($this->manager->find($rid));
     }
 } 

--- a/test/Doctrine/ODM/OrientDB/RepositoryTest.php
+++ b/test/Doctrine/ODM/OrientDB/RepositoryTest.php
@@ -38,9 +38,7 @@ class RepositoryTest extends TestCase
         $result->expects($this->at(0))
                ->method('getResult')
                ->will($this->returnValue($rawResult));
-        $result->expects($this->at(1))
-               ->method('getResult')
-               ->will($this->returnValue(array()));
+
 
         $binding = $this->getMock('Doctrine\OrientDB\Binding\BindingInterface');
         $binding->expects($this->any())

--- a/test/Integration/Document/City.php
+++ b/test/Integration/Document/City.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace test\Integration\Document;
+
+use Doctrine\ODM\OrientDB\Mapper\Annotations as ODM;
+
+/**
+ * @ODM\Document(class="City")
+ */
+class City extends Country
+{
+
+} 

--- a/test/Integration/Document/Country.php
+++ b/test/Integration/Document/Country.php
@@ -23,7 +23,7 @@ namespace test\Integration\Document;
 use Doctrine\ODM\OrientDB\Mapper\Annotations as ODM;
 
 /**
-* @ODM\Document(class="Country,City")
+* @ODM\Document(class="Country")
 */
 class Country
 {


### PR DESCRIPTION
This is still heavily a **WIP**.

It's my first step in getting the manager to actually manage entities. It is able to persist a document into the database. (It should be able to do multiple ones in a single transaction, but I haven't tested that yet.)

It can't yet handle embedded documents, links and edges.

I ran into some issues with the current implementation. The biggest one was the class annotation allowing several ODB classes to be mapped to a single PHP class, which makes it impossible to determine which ODB class is a new document should be, so now it takes the class property literally.

I decided to implement persistence by default using sql batches, which provide the highest performance since everything can be squeezed into 1 transaction (if I am correct). I added the PersisterInterface in case different implementations should be supported in the future, but I am actually against it. Inferior implementations shouldn't be encouraged in any sense and should a superior one appear, it should be the new standard. If you agree I will remove it, so any response on that?

I also changed the filling of proxies from the public vars/setters implementation to use Closures if available, or fall back to reflection. Public setters may have logic applied to them, in which case simply hydrating the value would result in a change.

Any problem with the changes above? I believe all of them are necessary.
