### PR TITLE
Fix mapping and hydration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
 before_script:
   - ./bin/initialize-dependencies.sh
   - ./bin/initialize-ci.sh 1.7.7

--- a/bin/initialize-ci.sh
+++ b/bin/initialize-ci.sh
@@ -33,5 +33,5 @@ echo "--- Starting an instance of OrientDB ---"
 sh -c $ODB_LAUNCHER </dev/null &>/dev/null &
 
 # Wait a bit for OrientDB to finish the initialization phase.
-sleep 5
+sleep 10
 printf "\n=== The CI environment has been initialized ===\n"

--- a/examples/menu.php
+++ b/examples/menu.php
@@ -14,10 +14,13 @@ $loader->register();
 $parameters = BindingParameters::create('http://admin:admin@127.0.0.1:2480/menu');
 $binding = new HttpBinding($parameters);
 
-$mapper = new ODM\Mapper(__DIR__ . '/../examples/proxies');
-$mapper->setDocumentDirectories(array(__DIR__.'/../examples/' => 'Domain'));
+$configuration = new ODM\Configuration(array(
+    'document_dirs' => array(__DIR__.'/../examples/' => 'Domain'),
+    'proxy_dir' => __DIR__ . '/../examples/proxies'
+));
 
-$manager = new ODM\Manager($mapper, $binding);
+
+$manager = new ODM\Manager($binding, $configuration);
 $menus = $manager->getRepository('Domain\Menu');
 
 foreach ($menus->findAll() as $menu) {

--- a/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
@@ -323,17 +323,11 @@ class ClassMetadata implements DoctrineMetadata
      */
     public function setDocumentValue($document, $property, $value)
     {
-        if (method_exists('\Closure', 'bind')) {
-            $setter = \Closure::bind(function ($document, $property, $value) {
-                    $document->$property = $value;
-                }, null, $document
-            );
-            $setter($document, $property, $value);
-        } else {
-            $reflProperty = $this->getReflectionClass()->getProperty($property);
-            $reflProperty->setAccessible(true);
-            $reflProperty->setValue($document, $value);
-        }
+        $setter = \Closure::bind(function ($document, $property, $value) {
+                $document->$property = $value;
+            }, null, $document
+        );
+        $setter($document, $property, $value);
     }
 
     /**

--- a/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadata.php
@@ -108,12 +108,12 @@ class ClassMetadata implements DoctrineMetadata
     /**
      * Checks if the given field is a mapped property for this class.
      *
-     * @param string $fieldName
+     * @param string $property The name of the property to which the field is mapped
      * @return boolean
      */
-    public function hasField($fieldName)
+    public function hasField($property)
     {
-        return (bool) $this->getField($fieldName);
+        return (bool) $this->getFieldByProperty($property);
     }
 
     /**
@@ -232,6 +232,9 @@ class ClassMetadata implements DoctrineMetadata
     {
         $this->reflFields = array();
         foreach ($this->getReflectionProperties() as $property) {
+            if (in_array($property->name, $this->getIdentifierFieldNames())) {
+                $property->setAccessible(true);
+            }
             $this->reflFields[$property->getName()] = $property;
         }
     }
@@ -311,6 +314,29 @@ class ClassMetadata implements DoctrineMetadata
     }
 
     /**
+     * Given a $property and its $value, sets that property on the given $document
+     * by using a closures if available, otherwise fall back to reflection.
+     *
+     * @param mixed $document
+     * @param string $property
+     * @param string $value
+     */
+    public function setDocumentValue($document, $property, $value)
+    {
+        if (method_exists('\Closure', 'bind')) {
+            $setter = \Closure::bind(function ($document, $property, $value) {
+                    $document->$property = $value;
+                }, null, $document
+            );
+            $setter($document, $property, $value);
+        } else {
+            $reflProperty = $this->getReflectionClass()->getProperty($property);
+            $reflProperty->setAccessible(true);
+            $reflProperty->setValue($document, $value);
+        }
+    }
+
+    /**
      * Returns all the possible associations mapped in the introspected class.
      *
      * @return Array
@@ -318,6 +344,23 @@ class ClassMetadata implements DoctrineMetadata
     protected function getAssociations()
     {
         return $this->associations;
+    }
+
+    /**
+     * Returns the reflection property associated with the $property.
+     *
+     * @param   string $field
+     * @return  Annotations\Property
+     */
+    protected function getFieldByProperty($property)
+    {
+        foreach ($this->getFields() as $key => $annotatedField) {
+            if ($property === $key) {
+                return $annotatedField;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadataFactory.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/ClassMetadataFactory.php
@@ -250,10 +250,11 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
                 if ('@rid' === $annotation->name) {
                     $foundIdentifier = true;
                     $metadata->setIdentifier($refProperty->getName());
+                    $fields[$refProperty->getName()] = $annotation;
                 } elseif (in_array($annotation->type, $this->getAssociationTypes())) {
-                    $associations[] = $annotation;
+                    $associations[$refProperty->getName()] = $annotation;
                 } else {
-                    $fields[] = $annotation;
+                    $fields[$refProperty->getName()] = $annotation;
                 }
             }
         }

--- a/src/Doctrine/ODM/OrientDB/Mapper/Hydration/Hydrator.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/Hydration/Hydrator.php
@@ -262,6 +262,10 @@ class Hydrator
             }
         }
 
+        if ($document instanceof Proxy) {
+            $document->__setInitialized(true);
+        }
+
         return $document;
     }
 

--- a/src/Doctrine/ODM/OrientDB/Mapper/Hydration/Hydrator.php
+++ b/src/Doctrine/ODM/OrientDB/Mapper/Hydration/Hydrator.php
@@ -246,6 +246,7 @@ class Hydrator
      */
     protected function fill($document, \stdClass $object)
     {
+        $metadata = $this->getMetadataFactory()->getMetadataFor(get_class($document));
         $propertyAnnotations = $this->getMetadataFactory()->getObjectPropertyAnnotations($document);
 
         foreach ($propertyAnnotations as $property => $annotation) {
@@ -256,12 +257,8 @@ class Hydrator
             }
 
             if (property_exists($object, $property)) {
-                $this->mapProperty(
-                    $document,
-                    $documentProperty,
-                    $object->$property,
-                    $annotation
-                );
+                $value = $this->hydrateValue($object->$property, $annotation);
+                $metadata->setDocumentValue($document, $documentProperty, $value);
             }
         }
 
@@ -280,17 +277,15 @@ class Hydrator
     }
 
     /**
-     * Given a $property and its $value, sets that property on the $given object
-     * using a public setter.
+     * Hydrates the value
      *
-     * @param mixed $document
-     * @param string $property
-     * @param string $value
+     * @param $value
      * @param PropertyAnnotation $annotation
      *
-     * @throws Exception
+     * @return mixed|null
+     * @throws \Exception
      */
-    protected function mapProperty($document, $property, $value, PropertyAnnotation $annotation)
+    protected function hydrateValue($value, PropertyAnnotation $annotation)
     {
         if ($annotation->type) {
             try {
@@ -303,26 +298,7 @@ class Hydrator
                 }
             }
         }
-
-        $setter = 'set' . $this->inflector->camelize($property);
-
-        if (method_exists($document, $setter)) {
-            $document->$setter($value);
-        }
-        else {
-            $refClass       = new \ReflectionObject($document);
-            $refProperty    = $refClass->getProperty($property);
-
-            if ($refProperty->isPublic()) {
-                $document->$property = $value;
-            } else {
-                throw new Exception(
-                    sprintf("%s has not method %s: you have to added the setter in order to correctly let Doctrine\OrientDB hydrate your object ?",
-                        get_class($document),
-                        $setter)
-                );
-            }
-        }
+        return $value;
     }
 
     /**

--- a/test/Doctrine/ODM/OrientDB/Document/Stub/Contact/Address.php
+++ b/test/Doctrine/ODM/OrientDB/Document/Stub/Contact/Address.php
@@ -12,7 +12,7 @@ class Address
     /**
      * @ODM\Property(name="@rid", type="string")
      */
-    public $rid;
+    protected $rid;
     /**
      * @ODM\Property(name="nojson", type="nojson")
      */

--- a/test/Doctrine/ODM/OrientDB/Integration/Proxy/ProxyFactoryTest.php
+++ b/test/Doctrine/ODM/OrientDB/Integration/Proxy/ProxyFactoryTest.php
@@ -30,7 +30,7 @@ class ProxyFactoryTest extends TestCase
 
         $rid = '#'.$this->getClassId('City').':0';
         $proxy = $manager->getReference($rid);
-        $this->assertEquals($rid, $proxy->rid);
+        $this->assertEquals($rid, $proxy->getRid());
         $this->assertFalse($proxy->__isInitialized());
         $this->assertEquals('Rome1', $proxy->name);
         $this->assertTrue($proxy->__isInitialized());
@@ -42,7 +42,7 @@ class ProxyFactoryTest extends TestCase
         $rid = '#'.$this->getClassId('City').':0';
         $proxy = $manager->find($rid);
         $this->assertTrue($proxy->__isInitialized());
-        $this->assertEquals($rid, $proxy->rid);
+        $this->assertEquals($rid, $proxy->getRid());
         $this->assertEquals('Rome1', $proxy->name);
     }
 
@@ -56,7 +56,7 @@ class ProxyFactoryTest extends TestCase
         $this->assertFalse($proxy->__isInitialized());
         $this->assertTrue($clone->__isInitialized());
 
-        $this->assertEquals($rid, $clone->rid);
+        $this->assertEquals($rid, $clone->getRid());
         $this->assertEquals('Rome1', $clone->name);
     }
 }

--- a/test/Integration/Document/Country.php
+++ b/test/Integration/Document/Country.php
@@ -30,10 +30,18 @@ class Country
     /**
      * @ODM\Property(name="@rid", type="string")
      */
-    public $rid;
+    protected $rid;
 
-	/**
-	 * @ODM\Property(name="name", type="string")
-	 */
-	public $name;
+    /**
+     * @ODM\Property(name="name", type="string")
+     */
+    public $name;
+
+    /**
+     * @return mixed
+     */
+    public function getRid()
+    {
+        return $this->rid;
+    }
 }

--- a/test/PHPUnit/TestCase.php
+++ b/test/PHPUnit/TestCase.php
@@ -9,6 +9,7 @@
 
 namespace test\PHPUnit;
 
+use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\ODM\OrientDB\Configuration;
 use Doctrine\ODM\OrientDB\Manager;
 use Doctrine\ODM\OrientDB\Mapper;
@@ -79,6 +80,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         return new Configuration(array_merge(
             array(
                 'proxy_dir' => $this->getProxyDirectory(),
+                'proxy_autogenerate_policy' => AbstractProxyFactory::AUTOGENERATE_ALWAYS,
                 'document_dirs' => array(__DIR__.'/../../test/Integration/Document' => 'test')
             ),
             $opts


### PR DESCRIPTION
So this is actually a fairly critical fix. Originally the mapping of ODB -> PHP was done via pubic vars and public setters.  I have already took a look at this in #186 but didn't realise that this was actually a more serious issue, due to the fact that the ProxyFactory from doctrine common uses reflection to set the RID on proxies, so in case they were protected, an error was thrown. Therefore I took my fix from there and extracted it so it can be merged earlier.

The 2nd thing is, when proxies were filled from collections, or queries they weren't marked as initialized so when touched they were hydrating again, querying the same data twice.

The last thing, which is not a bug but a note for writing tests: If mock result data is used (which I assume contains invalid RIDs), the rid property of the PHP object must be **protected**, public would result in the proxy trying to hydrate itself when the RID is set (since there is no public setter), which effectively means it will throw an error since the rid is invalid and can't be loaded. Actually I would encourage adding this as a note for all the mappings, RIDs are never meant to be set or changed, only fetched so mapping them as protected would make the most sense.

cc @weinr0ck 