### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "require": {
         "php": ">=5.3.3",
         "doctrine/common": "~2.2",
-        "symfony/finder": "~2.3",
-        "symfony/class-loader": "~2.3",
+        "symfony/finder": "~2.3|~3.0",
+        "symfony/class-loader": "~2.3|~3.0",
         "guzzle/guzzle": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0